### PR TITLE
Make the views work with the ONLY_FULL_GROUP_BY sql_mode enabled in 5.7

### DIFF
--- a/views/p_s/host_summary_57.sql
+++ b/views/p_s/host_summary_57.sql
@@ -63,7 +63,7 @@ SELECT accounts.host,
   JOIN sys.x$host_summary_by_file_io AS io ON accounts.host = io.host
   JOIN sys.x$memory_by_host_by_current_bytes mem ON accounts.host = mem.host
  WHERE accounts.host IS NOT NULL
- GROUP BY accounts.host;
+ GROUP BY accounts.host, mem.current_allocated, mem.total_allocated;
 
 /*
  * View: x$host_summary
@@ -115,4 +115,4 @@ SELECT accounts.host,
   JOIN sys.x$host_summary_by_file_io AS io ON accounts.host = io.host
   JOIN sys.x$memory_by_host_by_current_bytes mem ON accounts.host = mem.host
  WHERE accounts.host IS NOT NULL
- GROUP BY accounts.host;
+ GROUP BY accounts.host, mem.current_allocated, mem.total_allocated;

--- a/views/p_s/io_by_thread_by_latency.sql
+++ b/views/p_s/io_by_thread_by_latency.sql
@@ -67,7 +67,7 @@ SELECT IF(processlist_id IS NULL,
   LEFT JOIN performance_schema.threads USING (thread_id)
  WHERE event_name LIKE 'wait/io/file/%'
    AND sum_timer_wait > 0
- GROUP BY thread_id
+ GROUP BY thread_id, processlist_id, user
  ORDER BY SUM(sum_timer_wait) DESC;
 
 /*
@@ -124,5 +124,5 @@ SELECT IF(processlist_id IS NULL,
   LEFT JOIN performance_schema.threads USING (thread_id)
  WHERE event_name LIKE 'wait/io/file/%'
    AND sum_timer_wait > 0
- GROUP BY thread_id
+ GROUP BY thread_id, processlist_id, user
  ORDER BY SUM(sum_timer_wait) DESC;

--- a/views/p_s/processlist_57.sql
+++ b/views/p_s/processlist_57.sql
@@ -109,7 +109,9 @@ SELECT pps.thread_id AS thd_id,
   LEFT JOIN performance_schema.events_waits_current AS ewc USING (thread_id)
   LEFT JOIN performance_schema.events_statements_current as esc USING (thread_id)
   LEFT JOIN performance_schema.memory_summary_by_thread_by_event_name as mem USING (thread_id)
- GROUP BY thread_id
+ GROUP BY thread_id, conn_id, user, db, command, state, time, current_statement, lock_latency,
+          rows_examined, rows_sent, rows_affected, tmp_tables, tmp_disk_tables, full_scan, last_statement,
+          last_statement_latency, last_wait, last_wait_latency, source
  ORDER BY pps.processlist_time DESC, last_wait_latency DESC;
 
 /*
@@ -207,5 +209,7 @@ SELECT pps.thread_id AS thd_id,
   LEFT JOIN performance_schema.events_waits_current AS ewc USING (thread_id)
   LEFT JOIN performance_schema.events_statements_current as esc USING (thread_id)
   LEFT JOIN performance_schema.memory_summary_by_thread_by_event_name as mem USING (thread_id)
- GROUP BY thread_id
+ GROUP BY thread_id, conn_id, user, db, command, state, time, current_statement, lock_latency,
+          rows_examined, rows_sent, rows_affected, tmp_tables, tmp_disk_tables, full_scan, last_statement,
+          last_statement_latency, last_wait, last_wait_latency, source
  ORDER BY pps.processlist_time DESC, last_wait_latency DESC;

--- a/views/p_s/schema_table_statistics.sql
+++ b/views/p_s/schema_table_statistics.sql
@@ -124,7 +124,9 @@ SELECT pst.object_schema AS table_schema,
   LEFT JOIN x$ps_schema_table_statistics_io AS fsbi
     ON pst.object_schema = fsbi.table_schema
    AND pst.object_name = fsbi.table_name
- GROUP BY pst.object_schema, pst.object_name
+ GROUP BY pst.object_schema, pst.object_name, pst.sum_timer_wait, pst.count_fetch,
+          pst.sum_timer_fetch, pst.count_insert, pst.sum_timer_insert, pst.count_update,
+          pst.sum_timer_update, pst.count_delete, pst.sum_timer_delete
  ORDER BY pst.sum_timer_wait DESC;
 
 /* 
@@ -205,5 +207,7 @@ SELECT pst.object_schema AS table_schema,
   LEFT JOIN x$ps_schema_table_statistics_io AS fsbi
     ON pst.object_schema = fsbi.table_schema
    AND pst.object_name = fsbi.table_name
- GROUP BY pst.object_schema, pst.object_name
+ GROUP BY pst.object_schema, pst.object_name, pst.sum_timer_wait, pst.count_fetch,
+          pst.sum_timer_fetch, pst.count_insert, pst.sum_timer_insert, pst.count_update,
+          pst.sum_timer_update, pst.count_delete, pst.sum_timer_delete
  ORDER BY pst.sum_timer_wait DESC;

--- a/views/p_s/user_summary_57.sql
+++ b/views/p_s/user_summary_57.sql
@@ -64,7 +64,7 @@ SELECT IF(accounts.user IS NULL, 'background', accounts.user) AS user,
   LEFT JOIN sys.x$user_summary_by_statement_latency AS stmt ON IF(accounts.user IS NULL, 'background', accounts.user) = stmt.user
   LEFT JOIN sys.x$user_summary_by_file_io AS io ON IF(accounts.user IS NULL, 'background', accounts.user) = io.user
   LEFT JOIN sys.x$memory_by_user_by_current_bytes mem ON IF(accounts.user IS NULL, 'background', accounts.user) = mem.user
- GROUP BY IF(accounts.user IS NULL, 'background', accounts.user);
+ GROUP BY IF(accounts.user IS NULL, 'background', accounts.user), mem.current_allocated, mem.total_allocated;
 
 /*
  * View: x$user_summary
@@ -117,4 +117,4 @@ SELECT IF(accounts.user IS NULL, 'background', accounts.user) AS user,
   LEFT JOIN sys.x$user_summary_by_statement_latency AS stmt ON IF(accounts.user IS NULL, 'background', accounts.user) = stmt.user
   LEFT JOIN sys.x$user_summary_by_file_io AS io ON IF(accounts.user IS NULL, 'background', accounts.user) = io.user
   LEFT JOIN sys.x$memory_by_user_by_current_bytes mem ON IF(accounts.user IS NULL, 'background', accounts.user) = mem.user
- GROUP BY IF(accounts.user IS NULL, 'background', accounts.user);
+ GROUP BY IF(accounts.user IS NULL, 'background', accounts.user), mem.current_allocated, mem.total_allocated;


### PR DESCRIPTION
Make the views work with the ONLY_FULL_GROUP_BY sql_mode enabled. This is important as the mode is default in 5.7.5+.
