### PR TITLE
Fixing issue that memory_by_user and memory_by_host were grouping by a column that is ambiguous.

### DIFF
--- a/views/p_s/memory_by_host.sql
+++ b/views/p_s/memory_by_host.sql
@@ -49,7 +49,7 @@ SELECT IF(host IS NULL, 'background', host) AS host,
        sys.format_bytes(MAX(current_number_of_bytes_used)) AS current_max_alloc,
        sys.format_bytes(SUM(sum_number_of_bytes_alloc)) AS total_allocated
   FROM performance_schema.memory_summary_by_host_by_event_name
- GROUP BY host
+ GROUP BY IF(host IS NULL, 'background', host)
  ORDER BY SUM(current_number_of_bytes_used) DESC;
 
 /*
@@ -88,5 +88,5 @@ SELECT IF(host IS NULL, 'background', host) AS host,
        MAX(current_number_of_bytes_used) AS current_max_alloc,
        SUM(sum_number_of_bytes_alloc) AS total_allocated
   FROM performance_schema.memory_summary_by_host_by_event_name
- GROUP BY host
+ GROUP BY IF(host IS NULL, 'background', host)
  ORDER BY SUM(current_number_of_bytes_used) DESC;

--- a/views/p_s/memory_by_user.sql
+++ b/views/p_s/memory_by_user.sql
@@ -49,7 +49,7 @@ SELECT IF(user IS NULL, 'background', user) AS user,
        sys.format_bytes(MAX(current_number_of_bytes_used)) AS current_max_alloc,
        sys.format_bytes(SUM(sum_number_of_bytes_alloc)) AS total_allocated
   FROM performance_schema.memory_summary_by_user_by_event_name
- GROUP BY user
+ GROUP BY IF(user IS NULL, 'background', user)
  ORDER BY SUM(current_number_of_bytes_used) DESC;
 
 /*
@@ -88,5 +88,5 @@ SELECT IF(user IS NULL, 'background', user) AS user,
        MAX(current_number_of_bytes_used) AS current_max_alloc,
        SUM(sum_number_of_bytes_alloc) AS total_allocated
   FROM performance_schema.memory_summary_by_user_by_event_name
- GROUP BY user
+ GROUP BY IF(user IS NULL, 'background', user)
  ORDER BY SUM(current_number_of_bytes_used) DESC;


### PR DESCRIPTION
The memory_by_user and memory_by_host were grouping by user and host respectively. But those could both be a column in the underlying tables and in the resulting view. Changed to make it explicit to use the same expression as used for the view column.
