### PR TITLE
Rename ps_setup_disable_consumers.sql and ps_setup_enable_consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1776,7 +1776,7 @@ mysql> CALL sys.ps_setup_disable_instrument('');
 1 row in set (0.01 sec)
 ```
 
-#### ps_setup_disable_consumers
+#### ps_setup_disable_consumer
 
 ##### Description
 
@@ -1790,7 +1790,7 @@ Disables consumers within Performance Schema matching the input pattern.
 
 To disable all consumers:
 ```SQL
-mysql> CALL sys.ps_setup_disable_consumers('');
+mysql> CALL sys.ps_setup_disable_consumer('');
 +--------------------------+
 | summary                  |
 +--------------------------+
@@ -1801,7 +1801,7 @@ mysql> CALL sys.ps_setup_disable_consumers('');
 
 To disable just the event_stage consumers:
 ```SQL
-mysql> CALL sys.ps_setup_disable_consumers('stage');
+mysql> CALL sys.ps_setup_disable_consumer('stage');
 +------------------------+
 | summary                |
 +------------------------+
@@ -1862,7 +1862,7 @@ mysql> CALL sys.ps_setup_enable_background_threads();
 1 row in set (0.00 sec)
 ```
 
-#### ps_setup_enable_consumers
+#### ps_setup_enable_consumer
 
 ##### Description
 
@@ -1876,7 +1876,7 @@ Enables consumers within Performance Schema matching the input pattern.
 
 To enable all consumers:
 ```SQL
-mysql> CALL sys.ps_setup_enable_consumers('');
+mysql> CALL sys.ps_setup_enable_consumer('');
 +-------------------------+
 | summary                 |
 +-------------------------+
@@ -1887,7 +1887,7 @@ mysql> CALL sys.ps_setup_enable_consumers('');
 
 To enable just "waits" consumers:
 ```SQL
-mysql> CALL sys.ps_setup_enable_consumers('waits');
+mysql> CALL sys.ps_setup_enable_consumer('waits');
 +-----------------------+
 | summary               |
 +-----------------------+

--- a/procedures/ps_setup_disable_consumer.sql
+++ b/procedures/ps_setup_disable_consumer.sql
@@ -13,11 +13,11 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA */
 
-DROP PROCEDURE IF EXISTS ps_setup_disable_consumers;
+DROP PROCEDURE IF EXISTS ps_setup_disable_consumer;
 
 DELIMITER $$
 
-CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_disable_consumers (
+CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_disable_consumer (
         IN consumer VARCHAR(128)
     )
     COMMENT '
@@ -38,7 +38,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_disable_consumers (
 
              To disable all consumers:
 
-             mysql> CALL sys.ps_setup_disable_comsumers(\'\');
+             mysql> CALL sys.ps_setup_disable_consumer(\'\');
              +--------------------------+
              | summary                  |
              +--------------------------+

--- a/procedures/ps_setup_enable_consumer.sql
+++ b/procedures/ps_setup_enable_consumer.sql
@@ -13,11 +13,11 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA */
 
-DROP PROCEDURE IF EXISTS ps_setup_enable_consumers;
+DROP PROCEDURE IF EXISTS ps_setup_enable_consumer;
 
 DELIMITER $$
 
-CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_enable_consumers (
+CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_enable_consumer (
         IN consumer VARCHAR(128)
     )
     COMMENT '
@@ -38,7 +38,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_enable_consumers (
 
              To enable all consumers:
 
-             mysql> CALL sys.ps_setup_enable_consumers(\'\');
+             mysql> CALL sys.ps_setup_enable_consumer(\'\');
              +-------------------------+
              | summary                 |
              +-------------------------+
@@ -50,7 +50,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_enable_consumers (
 
              To enable just "waits" consumers:
 
-             mysql> CALL sys.ps_setup_enable_consumers(\'waits\');
+             mysql> CALL sys.ps_setup_enable_consumer(\'waits\');
              +-----------------------+
              | summary               |
              +-----------------------+

--- a/sys_56.sql
+++ b/sys_56.sql
@@ -84,12 +84,12 @@ SOURCE ./procedures/ps_trace_statement_digest.sql
 SOURCE ./procedures/ps_trace_thread.sql
 
 SOURCE ./procedures/ps_setup_disable_background_threads.sql
-SOURCE ./procedures/ps_setup_disable_consumers.sql
+SOURCE ./procedures/ps_setup_disable_consumer.sql
 SOURCE ./procedures/ps_setup_disable_instrument.sql
 SOURCE ./procedures/ps_setup_disable_thread.sql
 
 SOURCE ./procedures/ps_setup_enable_background_threads.sql
-SOURCE ./procedures/ps_setup_enable_consumers.sql
+SOURCE ./procedures/ps_setup_enable_consumer.sql
 SOURCE ./procedures/ps_setup_enable_instrument.sql
 SOURCE ./procedures/ps_setup_enable_thread.sql
 

--- a/sys_57.sql
+++ b/sys_57.sql
@@ -91,12 +91,12 @@ SOURCE ./procedures/ps_trace_statement_digest.sql
 SOURCE ./procedures/ps_trace_thread.sql
 
 SOURCE ./procedures/ps_setup_disable_background_threads.sql
-SOURCE ./procedures/ps_setup_disable_consumers.sql
+SOURCE ./procedures/ps_setup_disable_consumer.sql
 SOURCE ./procedures/ps_setup_disable_instrument.sql
 SOURCE ./procedures/ps_setup_disable_thread.sql
 
 SOURCE ./procedures/ps_setup_enable_background_threads.sql
-SOURCE ./procedures/ps_setup_enable_consumers.sql
+SOURCE ./procedures/ps_setup_enable_consumer.sql
 SOURCE ./procedures/ps_setup_enable_instrument.sql
 SOURCE ./procedures/ps_setup_enable_thread.sql
 


### PR DESCRIPTION
Rename ps_setup_disable_consumers.sql and ps_setup_enable_consumers to ps_setup_disable_consumer and ps_setup_enable_consumer respectively to provide consistency with the other procedures to enable/disable instruments and threads
