### PR TITLE
Dev/20141208 status metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Change history for the MySQL sys schema
 
+## 1.3.0 (23/10/2014)
+
+### Improvements
+
+* Added an `innodb_lock_waits` set of views, showing each thread that is waiting on a lock within InnoDB, and the blocking thread lock information (Contributed by Jesper Wisborg Krogh)
+
+### Bug Fixes
+
+* Fixed broken `host_summary_by_stages` views, broken with a last minute change before the 1.2.0 release that went unnoticed (facepalm)
+
 ## 1.2.0 (22/10/2014)
 
 ### Backwards Incompatible Changes
@@ -18,7 +28,7 @@
 * The `statements_with_full_table_scans` view now ignores any SQL that starts with `SHOW`
 * Added a script, `generate_sql_file.sh`, that can be used to generate a single SQL file, also allowing substitution of the MySQL user to use, and/or whether the `SET sql_log_bin ...` statements should be omitted.
 ** This is useful for those using RDS, where the root@localhost user is not accessible, and sql_log_bin is disabled (Issue #5)
-* Added a set `memory_by_thread_by_current_bytes` views, that summarize memory usage per thread with MySQL 5.7's memory instrumentation
+* Added a set of `memory_by_thread_by_current_bytes` views, that summarize memory usage per thread with MySQL 5.7's memory instrumentation
 * Improved each of the host specific views to return aggregate values for `background` threads, instead of ignoring them, in the same way as the user summary views
 
 ### Bug Fixes

--- a/before_setup.sql
+++ b/before_setup.sql
@@ -21,4 +21,4 @@ CREATE DATABASE IF NOT EXISTS sys DEFAULT CHARACTER SET utf8;
 
 USE sys;
 
-CREATE OR REPLACE VIEW version AS SELECT '1.2.0' AS sys_version, version() AS mysql_version;
+CREATE OR REPLACE VIEW version AS SELECT '1.3.0' AS sys_version, version() AS mysql_version;

--- a/views/p_s/host_summary.sql
+++ b/views/p_s/host_summary.sql
@@ -43,7 +43,7 @@ VIEW host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts
+  unique_users
 ) AS
 SELECT IF(accounts.host IS NULL, 'background', accounts.host) AS host,
        SUM(stmt.total) AS statements,
@@ -90,7 +90,7 @@ VIEW x$host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts
+  unique_users
 ) AS
 SELECT IF(accounts.host IS NULL, 'background', accounts.host) AS host,
        SUM(stmt.total) AS statements,

--- a/views/p_s/host_summary_57.sql
+++ b/views/p_s/host_summary_57.sql
@@ -44,7 +44,7 @@ VIEW host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts,
+  unique_users,
   current_memory,
   total_memory_allocated
 ) AS

--- a/views/p_s/host_summary_by_stages.sql
+++ b/views/p_s/host_summary_by_stages.sql
@@ -61,7 +61,7 @@ SELECT IF(host IS NULL, 'background', host) AS host,
        sys.format_time(sum_timer_wait) AS total_latency, 
        sys.format_time(avg_timer_wait) AS avg_latency 
   FROM performance_schema.events_stages_summary_by_host_by_event_name
-   AND sum_timer_wait != 0 
+ WHERE sum_timer_wait != 0
  ORDER BY IF(host IS NULL, 'background', host), sum_timer_wait DESC;
 
 /*
@@ -111,5 +111,5 @@ SELECT IF(host IS NULL, 'background', host) AS host,
        sum_timer_wait AS total_latency, 
        avg_timer_wait AS avg_latency 
   FROM performance_schema.events_stages_summary_by_host_by_event_name
-   AND sum_timer_wait != 0 
+ WHERE sum_timer_wait != 0
  ORDER BY IF(host IS NULL, 'background', host), sum_timer_wait DESC;


### PR DESCRIPTION
Adds the following:

* The ucfirst() function which takes a string and converts the first character to upper case and the rest to lower case.
* The view metrics which is a union of:
     - information_schema.GLOBAL_STATUS
     - information_schema.INNODB_METRICS
     - NOW()
     - UNIX_TIMESTAMP()
  The view uses the ucfirst() function to have all the global status variables and the InnoDB metrics names using the same convention as for the old SHOW GLOBAL STATUS.
  An Enabled column is included to make it easy to filter so just the enabled metrics are included.