### PR TITLE
The 5.6 host_summary and x$host_summary views and the 5.6 host_summary v...

### DIFF
--- a/views/p_s/host_summary.sql
+++ b/views/p_s/host_summary.sql
@@ -43,7 +43,7 @@ VIEW host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts
+  unique_users
 ) AS
 SELECT IF(accounts.host IS NULL, 'background', accounts.host) AS host,
        SUM(stmt.total) AS statements,
@@ -90,7 +90,7 @@ VIEW x$host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts
+  unique_users
 ) AS
 SELECT IF(accounts.host IS NULL, 'background', accounts.host) AS host,
        SUM(stmt.total) AS statements,

--- a/views/p_s/host_summary_57.sql
+++ b/views/p_s/host_summary_57.sql
@@ -44,7 +44,7 @@ VIEW host_summary (
   file_io_latency,
   current_connections,
   total_connections,
-  unique_hosts,
+  unique_users,
   current_memory,
   total_memory_allocated
 ) AS


### PR DESCRIPTION
...iew incorrectly had the column with COUNT(DISTINCT accounts.user) named unique_hosts instead of unique_users
