### PR TITLE
Ssl status per thread

### DIFF
--- a/sys_57.sql
+++ b/sys_57.sql
@@ -81,6 +81,8 @@ SOURCE ./views/p_s/schema_tables_with_full_table_scans.sql
 SOURCE ./views/p_s/x_schema_tables_with_full_table_scans.sql
 SOURCE ./views/p_s/schema_unused_indexes.sql
 
+SOURCE ./views/p_s/ssl_per_thread.sql
+
 SOURCE ./views/p_s/statement_analysis.sql
 SOURCE ./views/p_s/x_statement_analysis.sql
 SOURCE ./views/p_s/statements_with_errors_or_warnings.sql

--- a/views/p_s/ssl_per_thread.sql
+++ b/views/p_s/ssl_per_thread.sql
@@ -1,0 +1,33 @@
+-- View: ssl_per_thread
+--
+-- Show per thread ssl status
+--
+-- mysql> select * from ssl_per_thread;
+-- +-----------+-------------+--------------------+---------------------+
+-- | thread_id | ssl_version | ssl_cipher         | ssl_sessions_reused |
+-- +-----------+-------------+--------------------+---------------------+
+-- |        26 | TLSv1       | DHE-RSA-AES256-SHA | 0                   |
+-- |        27 | TLSv1       | DHE-RSA-AES256-SHA | 0                   |
+-- |        28 | TLSv1       | DHE-RSA-AES256-SHA | 0                   |
+-- +-----------+-------------+--------------------+---------------------+
+-- 3 rows in set (0.00 sec)
+
+
+CREATE 
+  ALGORITHM = MERGE
+  DEFINER = 'root'@'localhost'
+  SQL SECURITY INVOKER
+VIEW ssl_per_thread AS
+SELECT 
+  sslver.thread_id, 
+  sslver.variable_value ssl_version, 
+  sslcip.variable_value ssl_cipher,
+  sslreuse.variable_value ssl_sessions_reused
+FROM 
+  performance_schema.status_by_thread sslver 
+  LEFT JOIN performance_schema.status_by_thread sslcip 
+    ON (sslcip.thread_id=sslver.thread_id and sslcip.variable_name='Ssl_cipher')
+  LEFT JOIN performance_schema.status_by_thread sslreuse 
+    ON (sslreuse.thread_id=sslver.thread_id and sslreuse.variable_name='Ssl_sessions_reused') 
+WHERE 
+  sslver.variable_name='Ssl_version';


### PR DESCRIPTION
Inspired by http://www.depesz.com/2015/05/11/waiting-for-9-5-add-system-view-pg_stat_ssl/

It is missing information: 
* if and which client certificate was used.
* validity for the client certificate

Related: http://bugs.mysql.com/bug.php?id=77271