### PR TITLE
bytes were not rounded in format_bytes function

### DIFF
--- a/functions/format_bytes.sql
+++ b/functions/format_bytes.sql
@@ -77,7 +77,7 @@ BEGIN
   ELSEIF bytes >= 1073741824 THEN RETURN CONCAT(ROUND(bytes / 1073741824, 2), ' GiB');
   ELSEIF bytes >= 1048576 THEN RETURN CONCAT(ROUND(bytes / 1048576, 2), ' MiB');
   ELSEIF bytes >= 1024 THEN RETURN CONCAT(ROUND(bytes / 1024, 2), ' KiB');
-  ELSE RETURN CONCAT(ROUND(bytes, 0), ' bytes');
+  ELSE RETURN CONCAT(ROUND(bytes, 2), ' bytes');
   END IF;
 END$$
 


### PR DESCRIPTION
bytes were not rounded in format_bytes function


PRE FIX:

```
SELECT
ifnull((`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` / nullif(`performance_schema`.`file_summary_by_instance`.`COUNT_READ`,0)),0) as avg_reads_noformat,
`sys`.`format_bytes`(ifnull((`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` / nullif(`performance_schema`.`file_summary_by_instance`.`COUNT_READ`,0)),0)) AS `avg_read`
FROM `performance_schema`.`file_summary_by_instance`
ORDER BY (`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` + `performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_WRITE`) DESC limit 10
+--------------------+---------------------+
| avg_reads_noformat | avg_read            |
+--------------------+---------------------+
| 8192.0043          | 8.00 KiB            |
| 896.0000           | 896.000000000 bytes |
| 65534.6342         | 64.00 KiB           |
| 126.0000           | 126.000000000 bytes |
| 16384.0000         | 16.00 KiB           |
| 16384.0000         | 16.00 KiB           |
| 16384.0000         | 16.00 KiB           |
| 426.0000           | 426.000000000 bytes |
| 16384.0000         | 16.00 KiB           |
| 16384.0000         | 16.00 KiB           |
+--------------------+---------------------+



MariaDB [sys]> select sys.format_bytes (1000.0100);
+------------------------------+
| sys.format_bytes (1000.0100) |
+------------------------------+
| 1000.0100 bytes              |
+------------------------------+
1 row in set (0.00 sec)
```

FIX:


```
MariaDB [sys]> select sys.format_bytes (1000.0100);
+------------------------------+
| sys.format_bytes (1000.0100) |
+------------------------------+
| 1000.01 bytes                |
+------------------------------+
1 row in set (0.00 sec)

MariaDB [sys]> SELECT ifnull((`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` / nullif(`performance_schema`.`file_summary_by_instance`.`COUNT_READ`,0)),0) as avg_reads_noformat, `sys`.`format_bytes`(ifnull((`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` / nullif(`performance_schema`.`file_summary_by_instance`.`COUNT_READ`,0)),0)) AS `avg_read` FROM `performance_schema`.`file_summary_by_instance` ORDER BY (`performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_READ` + `performance_schema`.`file_summary_by_instance`.`SUM_NUMBER_OF_BYTES_WRITE`) DESC limit 10;
+--------------------+--------------+
| avg_reads_noformat | avg_read     |
+--------------------+--------------+
|          8192.0042 | 8.00 KiB     |
|           896.0000 | 896.00 bytes |
|         65534.6342 | 64.00 KiB    |
|           126.0000 | 126.00 bytes |
|         16384.0000 | 16.00 KiB    |
|         16384.0000 | 16.00 KiB    |
|         16384.0000 | 16.00 KiB    |
|           426.0000 | 426.00 bytes |
|         16384.0000 | 16.00 KiB    |
|         16384.0000 | 16.00 KiB    |
+--------------------+--------------+
```
