### PR TITLE
Removed the daemon command (conn_id=1) from the sessions processlist

### DIFF
--- a/views/p_s/sessions.sql
+++ b/views/p_s/sessions.sql
@@ -54,4 +54,5 @@ CREATE OR REPLACE
 VIEW sessions
  AS
 SELECT * FROM sys.processlist
-WHERE conn_id IS NOT NULL;
+WHERE conn_id IS NOT NULL AND command != 'Daemon';
+

--- a/views/p_s/x_sessions.sql
+++ b/views/p_s/x_sessions.sql
@@ -53,4 +53,4 @@ CREATE OR REPLACE
 VIEW x$sessions
  AS
 SELECT * FROM sys.x$processlist
-WHERE conn_id IS NOT NULL;
+WHERE conn_id IS NOT NULL AND command != 'Daemon';


### PR DESCRIPTION
This makes the view more compatible with the idea of sessions == show processlist.

Optional pull request of course, but I spotted this in the example for sys.processlist in README, and I liked it.