### PR TITLE
Oracle Bug#21550271: SYS.PS_SETUP_RESET_TO_DEFAULT FAILS DUE TO ENABLE/HISTORY COLUMN IN SETUP_ACTORS

### DIFF
--- a/mysql-test/suite/sysschema/r/pr_ps_setup_reset_to_default.result
+++ b/mysql-test/suite/sysschema/r/pr_ps_setup_reset_to_default.result
@@ -1,0 +1,27 @@
+CALL sys.ps_setup_reset_to_default(TRUE);
+status
+Resetting: setup_actors
+DELETE FROM performance_schema.setup_actors WHERE NOT (HOST = '%' AND USER = '%' AND ROLE = '%')
+status
+Resetting: setup_actors
+INSERT IGNORE INTO performance_schema.setup_actors VALUES ('%', '%', '%', 'YES', 'YES')
+status
+Resetting: setup_instruments
+UPDATE performance_schema.setup_instruments SET ENABLED = sys.ps_is_instrument_default_enabled(NAME), TIMED = sys.ps_is_instrument_default_timed(NAME)
+status
+Resetting: setup_consumers
+UPDATE performance_schema.setup_consumers SET ENABLED = IF(NAME IN ('events_statements_current', 'events_transactions_current', 'global_instrumentation', 'thread_instrumentation', 'statements_digest'), 'YES', 'NO')
+status
+Resetting: setup_objects
+DELETE FROM performance_schema.setup_objects WHERE NOT (OBJECT_TYPE IN ('EVENT', 'FUNCTION', 'PROCEDURE', 'TABLE', 'TRIGGER') AND OBJECT_NAME = '%'AND (OBJECT_SCHEMA = 'mysql'AND ENABLED = 'NO'AND TIMED = 'NO' ) OR (OBJECT_SCHEMA = 'performance_schema' AND ENABLED = 'NO'AND TIMED = 'NO' ) OR (OBJECT_SCHEMA = 'information_schema' AND ENABLED = 'NO'AND TIMED = 'NO' ) OR (OBJECT_SCHEMA = '%'AND ENABLED = 'YES' AND TIMED = 'YES'))
+status
+Resetting: setup_objects
+INSERT IGNORE INTO performance_schema.setup_objects VALUES ('EVENT', 'mysql' , '%', 'NO' , 'NO' ), ('EVENT', 'performance_schema', '%', 'NO' , 'NO' ), ('EVENT', 'information_schema', '%', 'NO' , 'NO' ), ('EVENT', '%' , '%', 'YES', 'YES'), ('FUNCTION' , 'mysql' , '%', 'NO' , 'NO' ), ('FUNCTION' , 'performance_schema', '%', 'NO' , 'NO' ), ('FUNCTION' , 'information_schema', '%', 'NO' , 'NO' ), ('FUNCTION' , '%' , '%', 'YES', 'YES'), ('PROCEDURE', 'mysql' , '%', 'NO' , 'NO' ), ('PROCEDURE', 'performance_schema', '%', 'NO' , 'NO' ), ('PROCEDURE', 'information_schema', '%', 'NO' , 'NO' ), ('PROCEDURE', '%' , '%', 'YES', 'YES'), ('TABLE', 'mysql' , '%', 'NO' , 'NO' ), ('TABLE', 'performance_schema', '%', 'NO' , 'NO' ), ('TABLE', 'information_schema', '%', 'NO' , 'NO' ), ('TABLE', '%' , '%', 'YES', 'YES'), ('TRIGGER', 'mysql' , '%', 'NO' , 'NO' ), ('TRIGGER', 'performance_schema', '%', 'NO' , 'NO' ), ('TRIGGER', 'information_schema', '%', 'NO' , 'NO' ), ('TRIGGER', '%' , '%', 'YES', 'YES')
+status
+Resetting: threads
+UPDATE performance_schema.threads SET INSTRUMENTED = 'YES'
+UPDATE performance_schema.setup_instruments SET enabled = 'YES', timed = 'YES';
+TRUNCATE TABLE performance_schema.setup_actors;
+INSERT INTO performance_schema.setup_actors VALUES ('%', '%', '%', 'YES', 'YES');
+UPDATE performance_schema.setup_consumers SET enabled = 'YES';
+UPDATE performance_schema.threads SET instrumented = 'YES';

--- a/mysql-test/suite/sysschema/t/pr_ps_setup_reset_to_default.test
+++ b/mysql-test/suite/sysschema/t/pr_ps_setup_reset_to_default.test
@@ -1,0 +1,15 @@
+########### suite/sysschema/t/pr_ps_setup_reset_to_default.test #############
+#                                                                           #
+# Testing of of the sys.ps_setup_reset_to_default() procedure               #
+#                                                                           #
+# Creation:                                                                 #
+# 2015-08-14 jkrogh Implement this test as part of Bug 21550271/Bug77927    #
+#                                                                           #
+#############################################################################
+
+-- source include/not_embedded.inc
+
+# Currently just a sanity check
+CALL sys.ps_setup_reset_to_default(TRUE);
+
+-- source ../include/ps_setup_reset_to_default_cleanup.inc

--- a/procedures/ps_setup_reset_to_default_57.sql
+++ b/procedures/ps_setup_reset_to_default_57.sql
@@ -70,7 +70,7 @@ BEGIN
     DEALLOCATE PREPARE reset_stmt;
 
     SET @query = 'INSERT IGNORE INTO performance_schema.setup_actors
-                  VALUES (''%'', ''%'', ''%'', ''YES'')';
+                  VALUES (''%'', ''%'', ''%'', ''YES'', ''YES'')';
 
     IF (in_verbose) THEN
         SELECT CONCAT('Resetting: setup_actors\n', REPLACE(@query, '  ', '')) AS status;


### PR DESCRIPTION
The performance_schema.setup_actors table has had the HISTORY column added to allow controlling whether the history is enabled by default for each actor ( http://dev.mysql.com/worklog/task/?id=7795 ).

This broke the ps_setup_reset_to_default() procedure in 5.7.8+.