### PR TITLE
Updating ps_is_instrument_default_enabed() and ps_is_instrument_defau…

### DIFF
--- a/functions/ps_is_instrument_default_enabled.sql
+++ b/functions/ps_is_instrument_default_enabled.sql
@@ -59,7 +59,13 @@ BEGIN
     SET v_enabled = IF(in_instrument LIKE 'wait/io/file/%'
                         OR in_instrument LIKE 'wait/io/table/%'
                         OR in_instrument LIKE 'statement/%'
-                        OR in_instrument IN ('wait/lock/table/sql/handler', 'idle'),
+                        OR in_instrument LIKE 'memory/performance_schema/%'
+                        OR in_instrument IN ('wait/lock/table/sql/handler', 'idle')
+               /*!50707
+                        OR in_instrument LIKE 'stage/innodb/%'
+                        OR in_instrument = 'stage/sql/copy to tmp table'
+               */
+                      ,
                        'YES',
                        'NO'
                     );

--- a/functions/ps_is_instrument_default_timed.sql
+++ b/functions/ps_is_instrument_default_timed.sql
@@ -59,7 +59,12 @@ BEGIN
     SET v_timed = IF(in_instrument LIKE 'wait/io/file/%'
                         OR in_instrument LIKE 'wait/io/table/%'
                         OR in_instrument LIKE 'statement/%'
-                        OR in_instrument IN ('wait/lock/table/sql/handler', 'idle'),
+                        OR in_instrument IN ('wait/lock/table/sql/handler', 'idle')
+               /*!50707
+                        OR in_instrument LIKE 'stage/innodb/%'
+                        OR in_instrument = 'stage/sql/copy to tmp table'
+               */
+                      ,
                        'YES',
                        'NO'
                     );


### PR DESCRIPTION
…lt_timed() to take the defaults for the new 5.7 instruments and for the change of defaults in 5.7.7

The tests done are:

SELECT * FROM performance_schema.setup_instruments WHERE sys.ps_is_instrument_default_enabled(NAME) <> ENABLED;

SELECT * FROM performance_schema.setup_instruments WHERE sys.ps_is_instrument_default_timed(NAME) <> TIMED;

Both should return 0 rows for a pass.

Versions tested are 5.7.6, 5.7.7, 5.7.8, 5.7.9 (from today) and 5.6.26