### PR TITLE
Dev/remove metrics 56

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,22 +1304,19 @@ mysql> select * from memory_global_total;
 +-----------------+
 ```
 
-#### metrics / metrics_56
+#### metrics
 
 ##### Description
 
 Creates a union of the following information:
 
-   *  performance_schema.global_status (information_schema.GLOBAL_STATUS for metrics_56)
+   *  performance_schema.global_status (information_schema.GLOBAL_STATUS in MySQL 5.6)
    *  information_schema.INNODB_METRICS
-   *  Performance Schema global memory usage information
+   *  Performance Schema global memory usage information (only in MySQL 5.7)
    *  Current time
 
-The difference between the metrics and the metrics_56 views are whether the global status is taken from performance_schema.global_status instead of
-from the Information Schema. Use the metrics view if the MySQL version is 5.6, 5.7.5 and earlier, or 5.7.6-5.7.8 with show_compatibility_56 = OFF. Otherwise use metrics_56.
-See also https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_show_compatibility_56
-
-In MySQL 5.7.6 and later the metrics_56 view will generate a warning that INFORMATION_SCHEMA.GLOBAL_STATUS is deprecated.
+In MySQL 5.7 it is required that performance_schema = ON, though there is no requirements to which
+instruments and consumers that are enabled. See also the description of the Enabled column below.
 
 For view has the following columns:
 
@@ -4255,7 +4252,7 @@ Query OK, 0 rows affected (0.00 sec)
 Create a report of the current status of the server for diagnostics purposes. Data collected includes (some items depends on versions and settings):
 
 * The GLOBAL VARIABLES
-* Several sys schema views including metrics or metrics_56
+* Several sys schema views including metrics or equivalent (depending on version and settings)
 * Queries in the 95th percentile
 * Several ndbinfo views for MySQL Cluster
 * Replication (both master and slave) information.
@@ -4271,9 +4268,13 @@ Some of the sys schema views are calculated as initial (optional), overall, delt
 * The delta view is the difference from the beginning to the end. Note that for min and max values
   they are simply the min or max value from the end view respectively, so does not necessarily reflect
   the minimum/maximum value in the monitored period.
-  Note: except for the metrics/metrics_56 views the delta is only calculation between the first and last outputs.
+  Note: except for the metrics view the delta is only calculation between the first and last outputs.
 
 Requires the SUPER privilege for "SET sql_log_bin = 0;".
+
+Versions supported:
+* MySQL 5.6: 5.6.10 and later
+* MySQL 5.7: 5.7.9 and later
 
 Some configuration options are supported:
 

--- a/mysql-test/suite/sysschema/r/all_sys_objects_exist.result
+++ b/mysql-test/suite/sysschema/r/all_sys_objects_exist.result
@@ -22,7 +22,6 @@ memory_by_user_by_current_bytes
 memory_global_by_current_bytes
 memory_global_total
 metrics
-metrics_56
 processlist
 ps_check_lost_instrumentation
 schema_auto_increment_columns

--- a/mysql-test/suite/sysschema/r/v_metrics.result
+++ b/mysql-test/suite/sysschema/r/v_metrics.result
@@ -5,10 +5,3 @@ Variable_value	text	YES		NULL
 Type	varchar(210)	YES		NULL	
 Enabled	varchar(7)	NO			
 SELECT * FROM sys.metrics;
-DESC sys.metrics_56;
-Field	Type	Null	Key	Default	Extra
-Variable_name	varchar(193)	YES		NULL	
-Variable_value	text	YES		NULL	
-Type	varchar(210)	YES		NULL	
-Enabled	varchar(7)	NO			
-SELECT * FROM sys.metrics_56;

--- a/mysql-test/suite/sysschema/t/v_metrics.test
+++ b/mysql-test/suite/sysschema/t/v_metrics.test
@@ -10,13 +10,3 @@ DESC sys.metrics;
 --disable_result_log
 SELECT * FROM sys.metrics;
 --enable_result_log
-
-
-# Ensure structure changes don't slip in
-DESC sys.metrics_56;
-
-# Make sure view select does not error, but ignore results
---disable_result_log
-SELECT * FROM sys.metrics_56;
---enable_result_log
-

--- a/sys_57.sql
+++ b/sys_57.sql
@@ -146,7 +146,6 @@ SOURCE ./views/p_s/waits_global_by_latency.sql
 SOURCE ./views/p_s/x_waits_global_by_latency.sql
 
 SOURCE ./views/p_s/metrics.sql
-SOURCE ./views/p_s/metrics_56.sql
 
 SOURCE ./views/p_s/processlist_57.sql
 SOURCE ./views/p_s/x_processlist_57.sql

--- a/views/p_s/metrics.sql
+++ b/views/p_s/metrics.sql
@@ -13,6 +13,9 @@
 --   along with this program; if not, write to the Free Software
 --   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA 
 
+-- IMPORTANT
+-- If you update this view, also update the "5.7+ and the Performance Schema disabled"
+-- query in procedures/diagnostics.sql
 
 -- View: metrics
 -- 

--- a/views/p_s/metrics_56.sql
+++ b/views/p_s/metrics_56.sql
@@ -14,7 +14,7 @@
 --   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA 
 
 
--- View: metrics_56
+-- View: metrics
 -- 
 -- Creates a union of the following information:
 --
@@ -70,8 +70,6 @@
 -- | trx_rw_commits                                | 0                       ...| InnoDB Metrics - transaction         | NO      |
 -- | trx_undo_slots_cached                         | 0                       ...| InnoDB Metrics - transaction         | NO      |
 -- | trx_undo_slots_used                           | 0                       ...| InnoDB Metrics - transaction         | NO      |
--- | memory_current_allocated                      | 138244216               ...| Performance Schema                   | PARTIAL |
--- | memory_total_allocated                        | 138244216               ...| Performance Schema                   | PARTIAL |
 -- | NOW()                                         | 2015-05-31 13:27:50.382 ...| System Time                          | YES     |
 -- | UNIX_TIMESTAMP()                              | 1433042870.382          ...| System Time                          | YES     |
 -- +-----------------------------------------------+-------------------------...+--------------------------------------+---------+
@@ -81,7 +79,7 @@ CREATE OR REPLACE
   ALGORITHM = TEMPTABLE
   DEFINER = 'root'@'localhost'
   SQL SECURITY INVOKER 
-VIEW metrics_56 (
+VIEW metrics (
   Variable_name,
   Variable_value,
   Type,
@@ -106,22 +104,7 @@ SELECT NAME AS Variable_name, COUNT AS Variable_value,
      'buffer_data_reads', 'buffer_data_written', 'file_num_open_files',
      'os_log_bytes_written', 'os_log_fsyncs', 'os_log_pending_fsyncs', 'os_log_pending_writes',
      'log_waits', 'log_write_requests', 'log_writes', 'innodb_dblwr_writes', 'innodb_dblwr_pages_written', 'innodb_page_size')
-) /*!50702
-  -- memory instrumentation available in 5.7.2 and later
-  UNION ALL (
-SELECT 'memory_current_allocated' AS Variable_name, SUM(CURRENT_NUMBER_OF_BYTES_USED) AS Variable_value, 'Performance Schema' AS Type,
-        IF((SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%' AND ENABLED = 'YES') = 0, 'NO',
-        IF((SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%' AND ENABLED = 'YES') = (SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%'), 'YES',
-            'PARTIAL')) AS Enabled
-  FROM performance_schema.memory_summary_global_by_event_name
 ) UNION ALL (
-SELECT 'memory_total_allocated' AS Variable_name, SUM(SUM_NUMBER_OF_BYTES_ALLOC) AS Variable_value, 'Performance Schema' AS Type,
-        IF((SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%' AND ENABLED = 'YES') = 0, 'NO',
-        IF((SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%' AND ENABLED = 'YES') = (SELECT COUNT(*) FROM performance_schema.setup_instruments WHERE NAME LIKE 'memory/%'), 'YES',
-            'PARTIAL')) AS Enabled
-  FROM performance_schema.memory_summary_global_by_event_name
-) */
-  UNION ALL (
 SELECT 'NOW()' AS Variable_name, NOW(3) AS Variable_value, 'System Time' AS Type, 'YES' AS Enabled
 ) UNION ALL (
 SELECT 'UNIX_TIMESTAMP()' AS Variable_name, ROUND(UNIX_TIMESTAMP(NOW(3)), 3) AS Variable_value, 'System Time' AS Type, 'YES' AS Enabled


### PR DESCRIPTION
Changing to metrics_56.sql is only used for MySQl 5.6 and will have the name metrics for all versions. This can be done as 5.7.9+ will support performance_schema.global_status for all configurations. Updated diagnostics() to always use metrics except when performance_schema = OFF in 5.7 as metrics requires the Performance_Schema engine to be available in 5.7.