### PR TITLE
Dev/20151019 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4972,10 +4972,10 @@ Requires the SUPER privilege for "SET sql_log_bin = 0;".
 ##### Parameters
 
 * in_digest VARCHAR(32): The statement digest identifier you would like to analyze
-* in_runtime (INT): The number of seconds to run analysis for (defaults to a minute)
-* in_interval (DECIMAL(2,2)): The interval (in seconds, may be fractional) at which to try and take snapshots (defaults to a second)
-* in_start_fresh (BOOLEAN): Whether to TRUNCATE the events_statements_history_long and events_stages_history_long tables before starting (default false)
-* in_auto_enable (BOOLEAN): Whether to automatically turn on required consumers (default false)
+* in_runtime (INT): The number of seconds to run analysis for
+* in_interval (DECIMAL(2,2)): The interval (in seconds, may be fractional) at which to try and take snapshots
+* in_start_fresh (BOOLEAN): Whether to TRUNCATE the events_statements_history_long and events_stages_history_long tables before starting
+* in_auto_enable (BOOLEAN): Whether to automatically turn on required consumers
 
 ##### Example
 ```SQL

--- a/README.md
+++ b/README.md
@@ -4650,15 +4650,17 @@ Saves the current configuration of Performance Schema, so that you can alter the
 
 Use the companion procedure - ps_setup_reload_saved(), to restore the saved config.
 
-Requires the SUPER privilege for "SET sql_log_bin = 0;".
+The named lock "sys.ps_setup_save" is taken before the current configuration is saved. If the attempt to get the named lock times out, an error occurs.
+
+The lock is released after the settings have been restored by calling ps_setup_reload_saved().Requires the SUPER privilege for "SET sql_log_bin = 0;".
 
 ##### Parameters
 
-None.
+* in_timeout (INT): The timeout in seconds used when trying to obtain the lock. A negative timeout means infinite timeout.
 
 ##### Example
 ```SQL
-mysql> CALL sys.ps_setup_save();
+mysql> CALL sys.ps_setup_save(-1);
 Query OK, 0 rows affected (0.08 sec)
 
 mysql> UPDATE performance_schema.setup_instruments 

--- a/README.md
+++ b/README.md
@@ -4638,7 +4638,7 @@ VALUES ('%', '%', '%')
 1 row in set (0.00 sec)
 ...
 
-mysql> CALL sys.ps_setup_reset_to_default(false)G
+mysql> CALL sys.ps_setup_reset_to_default(false)\G
 Query OK, 0 rows affected (0.00 sec)
 ```
 
@@ -4929,7 +4929,7 @@ None.
 
 ##### Example
 ```SQL
-mysql> CALL sys.ps_statement_avg_latency_histogram()G
+mysql> CALL sys.ps_statement_avg_latency_histogram()\G
 *************************** 1. row ***************************
 Performance Schema Statement Digest Average Latency Histogram:
 

--- a/README.md
+++ b/README.md
@@ -3608,7 +3608,7 @@ Useful for printing statement related data from Performance Schema from the comm
 
 ##### Returns
 
-VARCHAR(65)
+LONGTEXT
 
 ##### Example
 ```SQL

--- a/functions/format_statement.sql
+++ b/functions/format_statement.sql
@@ -43,7 +43,7 @@ CREATE DEFINER='root'@'localhost' FUNCTION format_statement (
              Returns
              -----------
 
-             VARCHAR(65)
+             LONGTEXT
 
              Example
              -----------

--- a/functions/ps_thread_trx_info.sql
+++ b/functions/ps_thread_trx_info.sql
@@ -52,7 +52,7 @@ CREATE DEFINER='root'@'localhost' FUNCTION ps_thread_trx_info (
              Example
              -----------
 
-             SELECT sys.ps_thread_trx_info(48)\G
+             SELECT sys.ps_thread_trx_info(48)\\G
              *************************** 1. row ***************************
              sys.ps_thread_trx_info(48): [
                {

--- a/procedures/ps_setup_reset_to_default.sql
+++ b/procedures/ps_setup_reset_to_default.sql
@@ -50,7 +50,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_reset_to_default (
              1 row in set (0.00 sec)
              ...
 
-             mysql> CALL sys.ps_setup_reset_to_default(false)\G
+             mysql> CALL sys.ps_setup_reset_to_default(false)\\G
              Query OK, 0 rows affected (0.00 sec)
             '
     SQL SECURITY INVOKER

--- a/procedures/ps_setup_reset_to_default_57.sql
+++ b/procedures/ps_setup_reset_to_default_57.sql
@@ -50,7 +50,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_reset_to_default (
              1 row in set (0.00 sec)
              ...
 
-             mysql> CALL sys.ps_setup_reset_to_default(false)\G
+             mysql> CALL sys.ps_setup_reset_to_default(false)\\G
              Query OK, 0 rows affected (0.00 sec)
             '
     SQL SECURITY INVOKER

--- a/procedures/ps_setup_save.sql
+++ b/procedures/ps_setup_save.sql
@@ -31,17 +31,26 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_setup_save (
              Use the companion procedure - ps_setup_reload_saved(), to 
              restore the saved config.
 
+             The named lock "sys.ps_setup_save" is taken before the
+             current configuration is saved. If the attempt to get the named
+             lock times out, an error occurs.
+
+             The lock is released after the settings have been restored by
+             calling ps_setup_reload_saved().
+
              Requires the SUPER privilege for "SET sql_log_bin = 0;".
 
              Parameters
              -----------
 
-             None.
+             in_timeout INT
+               The timeout in seconds used when trying to obtain the lock.
+               A negative timeout means infinite timeout.
 
              Example
              -----------
 
-             mysql> CALL sys.ps_setup_save();
+             mysql> CALL sys.ps_setup_save(-1);
              Query OK, 0 rows affected (0.08 sec)
 
              mysql> UPDATE performance_schema.setup_instruments 

--- a/procedures/ps_statement_avg_latency_histogram.sql
+++ b/procedures/ps_statement_avg_latency_histogram.sql
@@ -37,7 +37,7 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_statement_avg_latency_histogram (
              Example
              -----------
 
-             mysql> CALL sys.ps_statement_avg_latency_histogram()\G
+             mysql> CALL sys.ps_statement_avg_latency_histogram()\\G
              *************************** 1. row ***************************
              Performance Schema Statement Digest Average Latency Histogram:
 

--- a/procedures/ps_trace_statement_digest.sql
+++ b/procedures/ps_trace_statement_digest.sql
@@ -51,15 +51,15 @@ CREATE DEFINER='root'@'localhost' PROCEDURE ps_trace_statement_digest (
              in_digest (VARCHAR(32)):
                The statement digest identifier you would like to analyze
              in_runtime (INT):
-               The number of seconds to run analysis for (defaults to a minute)
+               The number of seconds to run analysis for
              in_interval (DECIMAL(2,2)):
                The interval (in seconds, may be fractional) at which to try
-               and take snapshots (defaults to a second)
+               and take snapshots
              in_start_fresh (BOOLEAN):
                Whether to TRUNCATE the events_statements_history_long and
-               events_stages_history_long tables before starting (default false)
+               events_stages_history_long tables before starting
              in_auto_enable (BOOLEAN):
-               Whether to automatically turn on required consumers (default false)
+               Whether to automatically turn on required consumers
 
              Example
              -----------


### PR DESCRIPTION
Various updates of the documentation and to the routine comments:
* The documentation for ps_trace_statement_digest() said several of the parameters had default values, but that was not the case.
* format_statement() was listed to return a VARCHAR(65), but that is no longer correct. It is now a LONGTEXT.
* The argument (in_timeout) for ps_setup_save() was not documented.
* For routine comments, in \G the backslash must be escaped or it's lost when routine is created. This also meant that the backslash was missing in some examples in the README file.
