### PR TITLE
Changing the pr_statement_performance_analyzer test into a sanity che…

### DIFF
--- a/mysql-test/suite/sysschema/r/pr_statement_performance_analyzer.result
+++ b/mysql-test/suite/sysschema/r/pr_statement_performance_analyzer.result
@@ -15,7 +15,6 @@ id	val
 CALL sys.statement_performance_analyzer('create_tmp', 'test.tmp_digests_ini', NULL);
 CALL sys.statement_performance_analyzer('snapshot', NULL, NULL);
 CALL sys.statement_performance_analyzer('save', 'test.tmp_digests_ini', NULL);
-DO SLEEP(1.2);
 INSERT INTO t1 VALUES (2, 0);
 UPDATE t1 SET val = 1 WHERE id = 2;
 SELECT t1a.* FROM t1 AS t1a LEFT OUTER JOIN (SELECT * FROM t1 AS t1b1 INNER JOIN t1 AS t1b2 USING (id, val)) AS t1b ON t1b.id > t1a.id ORDER BY t1a.val, t1a.id;
@@ -23,65 +22,18 @@ id	val
 1	1
 2	1
 CALL sys.statement_performance_analyzer('snapshot', NULL, NULL);
-SELECT DIGEST, COUNT_STAR FROM performance_schema.events_statements_summary_by_digest;
-DIGEST	COUNT_STAR
-DIGEST_INSERT	2
-DIGEST_SELECT	2
-DIGEST_UPDATE	2
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_runtimes_in_95th_percentile');
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_runtimes_in_95th_percentile');
 CALL sys.statement_performance_analyzer('overall', NULL, 'analysis');
-Next Output
-QUERY_INSERT	test		2	0	0	LATENCY	LATENCY	LATENCY	LATENCY	0	0	0	0	2	1	0	0	0	0	DIGEST_INSERT	FIRST_SEEN	LAST_SEEN
-QUERY_SELECT	test	*	2	0	0	LATENCY	LATENCY	LATENCY	LATENCY	3	2	15	8	0	0	2	0	3	0	DIGEST_SELECT	FIRST_SEEN	LAST_SEEN
-QUERY_UPDATE	test		2	0	0	LATENCY	LATENCY	LATENCY	LATENCY	0	0	2	1	2	1	0	0	0	0	DIGEST_UPDATE	FIRST_SEEN	LAST_SEEN
-Top 100 Queries Ordered by Total Latency
-query	db	full_scan	exec_count	err_count	warn_count	total_latency	max_latency	avg_latency	lock_latency	rows_sent	rows_sent_avg	rows_examined	rows_examined_avg	rows_affected	rows_affected_avg	tmp_tables	tmp_disk_tables	rows_sorted	sort_merge_passes	digest	first_seen	last_seen
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'analysis');
-Next Output
-QUERY_INSERT	test		1	0	0	LATENCY	LATENCY	LATENCY	LATENCY	0	0	0	0	1	1	0	0	0	0	DIGEST_INSERT	FIRST_SEEN	LAST_SEEN
-QUERY_SELECT	test	*	1	0	0	LATENCY	LATENCY	LATENCY	LATENCY	2	2	10	10	0	0	1	0	2	0	DIGEST_SELECT	FIRST_SEEN	LAST_SEEN
-QUERY_UPDATE	test		1	0	0	LATENCY	LATENCY	LATENCY	LATENCY	0	0	1	1	1	1	0	0	0	0	DIGEST_UPDATE	FIRST_SEEN	LAST_SEEN
-Top 100 Queries Ordered by Total Latency
-query	db	full_scan	exec_count	err_count	warn_count	total_latency	max_latency	avg_latency	lock_latency	rows_sent	rows_sent_avg	rows_examined	rows_examined_avg	rows_affected	rows_affected_avg	tmp_tables	tmp_disk_tables	rows_sorted	sort_merge_passes	digest	first_seen	last_seen
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_errors_or_warnings');
-Next Output
-Top 100 Queries with Errors
-query	db	exec_count	errors	error_pct	warnings	warning_pct	first_seen	last_seen	digest
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_errors_or_warnings');
-Next Output
-Top 100 Queries with Errors
-query	db	exec_count	errors	error_pct	warnings	warning_pct	first_seen	last_seen	digest
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_full_table_scans');
-Next Output
-Top 100 Queries with Full Table Scan
-query	db	exec_count	total_latency	no_index_used_count	no_good_index_used_count	no_index_used_pct	rows_sent	rows_examined	rows_sent_avg	rows_examined_avg	first_seen	last_seen	digest
-QUERY_SELECT	test	2	LATENCY	2	0	100	3	15	2	8	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_full_table_scans');
-Next Output
-Top 100 Queries with Full Table Scan
-query	db	exec_count	total_latency	no_index_used_count	no_good_index_used_count	no_index_used_pct	rows_sent	rows_examined	rows_sent_avg	rows_examined_avg	first_seen	last_seen	digest
-QUERY_SELECT	test	1	LATENCY	1	0	100	2	10	2	10	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_sorting');
-Next Output
-Top 100 Queries with Sorting
-query	db	exec_count	total_latency	sort_merge_passes	avg_sort_merges	sorts_using_scans	sort_using_range	rows_sorted	avg_rows_sorted	first_seen	last_seen	digest
-QUERY_SELECT	test	2	LATENCY	0	0	2	0	3	2	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_sorting');
-Next Output
-Top 100 Queries with Sorting
-query	db	exec_count	total_latency	sort_merge_passes	avg_sort_merges	sorts_using_scans	sort_using_range	rows_sorted	avg_rows_sorted	first_seen	last_seen	digest
-QUERY_SELECT	test	1	LATENCY	0	0	1	0	2	2	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_temp_tables');
-Next Output
-Top 100 Queries with Internal Temporary Tables
-query	db	exec_count	total_latency	memory_tmp_tables	disk_tmp_tables	avg_tmp_tables_per_query	tmp_tables_to_disk_pct	first_seen	last_seen	digest
-QUERY_SELECT	test	2	LATENCY	2	0	1	0	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_temp_tables');
-Next Output
-Top 100 Queries with Internal Temporary Tables
-query	db	exec_count	total_latency	memory_tmp_tables	disk_tmp_tables	avg_tmp_tables_per_query	tmp_tables_to_disk_pct	first_seen	last_seen	digest
-QUERY_SELECT	test	1	LATENCY	1	0	1	0	FIRST_SEEN	LAST_SEEN	DIGEST_SELECT
 CREATE VIEW test.view_digests AS
 SELECT sys.format_statement(DIGEST_TEXT) AS query,
 SCHEMA_NAME AS db,
@@ -96,26 +48,9 @@ FROM performance_schema.events_statements_summary_by_digest
 ORDER BY SUBSTRING(query, 1, 6);
 SET @sys.statement_performance_analyzer.view = 'test.view_digests';
 CALL sys.statement_performance_analyzer('overall', NULL, 'custom');
-Next Output
-Top 100 Queries Using Custom View
-query	db	exec_count	total_latency	avg_latency	rows_sent_avg	rows_examined_avg	rows_affected_avg	digest
-QUERY_INSERT	test	2	LATENCY	LATENCY	0	0	1	DIGEST_INSERT
-QUERY_SELECT	test	2	LATENCY	LATENCY	2	8	0	DIGEST_SELECT
-QUERY_UPDATE	test	2	LATENCY	LATENCY	0	1	1	DIGEST_UPDATE
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'custom');
-Next Output
-Top 100 Queries Using Custom View
-query	db	exec_count	total_latency	avg_latency	rows_sent_avg	rows_examined_avg	rows_affected_avg	digest
-QUERY_INSERT	test	1	LATENCY	LATENCY	0	0	1	DIGEST_INSERT
-QUERY_SELECT	test	1	LATENCY	LATENCY	2	10	0	DIGEST_SELECT
-QUERY_UPDATE	test	1	LATENCY	LATENCY	0	1	1	DIGEST_UPDATE
 SET @sys.statement_performance_analyzer.limit = 2;
 CALL sys.statement_performance_analyzer('overall', NULL, 'custom');
-Next Output
-Top 2 Queries Using Custom View
-query	db	exec_count	total_latency	avg_latency	rows_sent_avg	rows_examined_avg	rows_affected_avg	digest
-QUERY_INSERT	test	2	LATENCY	LATENCY	0	0	1	DIGEST_INSERT
-QUERY_SELECT	test	2	LATENCY	LATENCY	2	8	0	DIGEST_SELECT
 SET SESSION sql_mode = 'NO_AUTO_CREATE_USER';
 CALL sys.statement_performance_analyzer('do magic', NULL, NULL);
 ERROR 45000: Unknown action. Supported actions are: cleanup, create_table, create_tmp, delta, overall, save, snapshot
@@ -188,6 +123,7 @@ SET SESSION sql_mode = @@global.sql_mode;
 SET @sys.statement_performance_analyzer.limit = NULL;
 SET @sys.statement_performance_analyzer.view = NULL;
 UPDATE performance_schema.setup_consumers SET enabled = 'YES';
+UPDATE performance_schema.threads SET instrumented = 'YES';
 SET @sys.ignore_sys_config_triggers := true;
 DELETE FROM sys.sys_config;
 INSERT IGNORE INTO sys.sys_config (variable, value) VALUES

--- a/mysql-test/suite/sysschema/t/pr_statement_performance_analyzer.test
+++ b/mysql-test/suite/sysschema/t/pr_statement_performance_analyzer.test
@@ -39,53 +39,21 @@ CALL sys.ps_setup_enable_consumer('events_statements_history_long');
 CALL sys.ps_truncate_all_tables(FALSE);
 --enable_result_log
 
-# The sleeps of more than 1 second ensures that the first_seen and last_seen will not be within the
-# same second and thus will be unique for all of the queries. This is required for the result substitution to
-# be deterministic.
-
 # Start with some initial queries
-# Don't rely on the digests being constant across MySQL releases and versions, so find the
-# digest for each of the three queries by getting the last event from performance_schema.events_statements_current
-# for the con1 connection.
 connection con1;
 INSERT INTO t1 VALUES (1, 0);
-connection default;
-#--let $wait_condition= SELECT COUNT(*) = 1 FROM t1
---let $wait_condition= SELECT SUBSTRING(SQL_TEXT, 1, 7) = 'INSERT ' FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id AND DIGEST IS NOT NULL
---source include/wait_condition.inc
---let $digest_insert= `SELECT DIGEST FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
---let $query_insert= `SELECT sys.format_statement(DIGEST_TEXT) FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
-connection con1;
 UPDATE t1 SET val = 1 WHERE id = 1;
-connection default;
-#--let $wait_condition= SELECT val = 1 FROM t1 WHERE id = 1;
---let $wait_condition= SELECT SUBSTRING(SQL_TEXT, 1, 7) = 'UPDATE ' FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id AND DIGEST IS NOT NULL
---source include/wait_condition.inc
---let $digest_update= `SELECT DIGEST FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
---let $query_update= `SELECT sys.format_statement(DIGEST_TEXT) FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
-connection con1;
 SELECT t1a.* FROM t1 AS t1a LEFT OUTER JOIN (SELECT * FROM t1 AS t1b1 INNER JOIN t1 AS t1b2 USING (id, val)) AS t1b ON t1b.id > t1a.id ORDER BY t1a.val, t1a.id;
+
 connection default;
---let $wait_condition= SELECT SUBSTRING(SQL_TEXT, 1, 7) = 'SELECT ' FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id AND DIGEST IS NOT NULL
+# Make sure all of the queries executing in con1 has been recorded in performance_schema.events_statements_summary_by_digest
+# before continuing with the actual tests of pr_statement_performance_analyzer()
+--let $wait_condition= SELECT COUNT_STAR = 1 FROM performance_schema.events_statements_summary_by_digest WHERE DIGEST_TEXT LIKE 'SELECT %'
 --source include/wait_condition.inc
---let $digest_select= `SELECT DIGEST FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
---let $query_select= `SELECT sys.format_statement(DIGEST_TEXT) FROM performance_schema.events_statements_current WHERE THREAD_ID = $con1_thread_id ORDER BY EVENT_ID DESC LIMIT 1`
-
-# Enable to debug if some digests are not found
-# --output /tmp/digest
-# --eval SELECT '$digest_insert' AS DigestInsert, '$digest_update' AS DigestUpdate, '$digest_select' AS DigestSelect
-# --output /tmp/digest_text
-# --eval SELECT '$query_insert' AS DigestInsert, '$query_update' AS DigestUpdate, '$query_select' AS DigestSelect
-# --output /tmp/ps_history
-# SELECT THREAD_ID, EVENT_ID, END_EVENT_ID, DIGEST, SQL_TEXT FROM performance_schema.events_statements_history_long ORDER BY EVENT_ID;
-
 # Start collecting data
 CALL sys.statement_performance_analyzer('create_tmp', 'test.tmp_digests_ini', NULL);
 CALL sys.statement_performance_analyzer('snapshot', NULL, NULL);
 CALL sys.statement_performance_analyzer('save', 'test.tmp_digests_ini', NULL);
-
-# Make sure the last_seen times will be different from the SELECT statement's first_seen.
-DO SLEEP(1.2);
 
 # Make some more changes
 connection con1;
@@ -98,74 +66,35 @@ disconnect con1;
 connection default;
 # Make sure all of the queries executing in con1 has been recorded in performance_schema.events_statements_summary_by_digest
 # before continuing with the actual tests of pr_statement_performance_analyzer()
---let $wait_condition= SELECT COUNT_STAR = 2 FROM performance_schema.events_statements_summary_by_digest WHERE DIGEST = '$digest_select'
+--let $wait_condition= SELECT COUNT_STAR = 2 FROM performance_schema.events_statements_summary_by_digest WHERE DIGEST_TEXT LIKE 'SELECT %'
 --source include/wait_condition.inc
 CALL sys.statement_performance_analyzer('snapshot', NULL, NULL);
 
-# Do a sanity check to ensure we are assuming the queries has the digests they have and that there is nothing else in the events_statements_summary_by_digest than there actually is.
---replace_result $digest_insert DIGEST_INSERT $digest_update DIGEST_UPDATE $digest_select DIGEST_SELECT
---sorted_result
-SELECT DIGEST, COUNT_STAR FROM performance_schema.events_statements_summary_by_digest;
+# The actual result is unknown so just check whether any warnings or errors occur.
+--disable_result_log
 
 # with_runtimes_in_95th_percentile
-# It is unknown what the result will be since the execution times for each query are unknown
-# So just check that no warning or error occurs
---disable_result_log
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_runtimes_in_95th_percentile');
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_runtimes_in_95th_percentile');
---enable_result_log
 
-# analysis - as there's no control of the lock time, it may be the same for two or more of the queries.
-# So replace_result cannot be used to give it a unique value. Instead just use LOCK_LATENCY for all rows.
---let $o_upd_total_latency= `SELECT total_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_upd_max_latency= `SELECT max_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_upd_avg_latency= `SELECT avg_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_upd_first_seen= `SELECT first_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_upd_last_seen= `SELECT last_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_sel_total_latency= `SELECT total_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_sel_max_latency= `SELECT max_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_sel_avg_latency= `SELECT avg_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_sel_first_seen= `SELECT first_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_sel_last_seen= `SELECT last_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_ins_total_latency= `SELECT total_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---let $o_ins_max_latency= `SELECT max_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---let $o_ins_avg_latency= `SELECT avg_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---let $o_ins_first_seen= `SELECT first_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---let $o_ins_last_seen= `SELECT last_seen FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---let $o_upd_lock_latency= `SELECT lock_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_update'`
---let $o_sel_lock_latency= `SELECT lock_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_select'`
---let $o_ins_lock_latency= `SELECT lock_latency FROM sys.statement_analysis WHERE db = 'test' AND digest = '$digest_insert'`
---replace_result $query_insert QUERY_INSERT $query_select QUERY_SELECT $query_update QUERY_UPDATE $digest_insert DIGEST_INSERT $digest_update DIGEST_UPDATE $digest_select DIGEST_SELECT $o_upd_total_latency LATENCY $o_upd_max_latency LATENCY $o_upd_avg_latency LATENCY $o_upd_lock_latency LATENCY $o_upd_first_seen FIRST_SEEN $o_upd_last_seen LAST_SEEN $o_sel_total_latency LATENCY $o_sel_max_latency LATENCY $o_sel_avg_latency LATENCY $o_sel_lock_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN $o_ins_total_latency LATENCY $o_ins_max_latency LATENCY $o_ins_avg_latency LATENCY $o_ins_lock_latency LATENCY $o_ins_first_seen FIRST_SEEN $o_ins_last_seen LAST_SEEN
---sorted_result
+# analysis
 CALL sys.statement_performance_analyzer('overall', NULL, 'analysis');
-
---let $d_upd_total_latency= `SELECT sys.format_time(TIMER_WAIT) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_update' ORDER BY EVENT_ID DESC LIMIT 1`
---let $d_sel_total_latency= `SELECT sys.format_time(TIMER_WAIT) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_select' ORDER BY EVENT_ID DESC LIMIT 1`
---let $d_ins_total_latency= `SELECT sys.format_time(TIMER_WAIT) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_insert' ORDER BY EVENT_ID DESC LIMIT 1`
---let $d_upd_tock_latency= `SELECT sys.format_time(LOCK_TIME) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_update' ORDER BY EVENT_ID DESC LIMIT 1`
---let $d_sel_tock_latency= `SELECT sys.format_time(LOCK_TIME) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_select' ORDER BY EVENT_ID DESC LIMIT 1`
---let $d_ins_tock_latency= `SELECT sys.format_time(LOCK_TIME) FROM performance_schema.events_statements_history_long WHERE CURRENT_SCHEMA = 'test' AND DIGEST = '$digest_insert' ORDER BY EVENT_ID DESC LIMIT 1`
---replace_result $query_insert QUERY_INSERT $query_select QUERY_SELECT $query_update QUERY_UPDATE $digest_insert DIGEST_INSERT $digest_update DIGEST_UPDATE $digest_select DIGEST_SELECT $d_upd_total_latency LATENCY $o_upd_max_latency LATENCY $o_upd_first_seen FIRST_SEEN $o_upd_last_seen LAST_SEEN $d_upd_tock_latency LATENCY $d_sel_total_latency LATENCY $o_sel_max_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN $d_sel_tock_latency LATENCY $d_ins_total_latency LATENCY $o_ins_max_latency LATENCY $o_ins_first_seen FIRST_SEEN $o_ins_last_seen LAST_SEEN $d_ins_tock_latency LATENCY
---sorted_result
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'analysis');
 
-# Should give an empty result except for the banner generated by the procedure
+# with_errors_or_warnings
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_errors_or_warnings');
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_errors_or_warnings');
 
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $o_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
+# with_full_table_scans
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_full_table_scans');
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $d_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_full_table_scans');
 
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $o_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
+# with_sorting
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_sorting');
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $d_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_sorting');
 
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $o_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
+# with_temp_tables
 CALL sys.statement_performance_analyzer('overall', NULL, 'with_temp_tables');
---replace_result $query_select QUERY_SELECT $digest_select DIGEST_SELECT $d_sel_total_latency LATENCY $o_sel_first_seen FIRST_SEEN $o_sel_last_seen LAST_SEEN
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'with_temp_tables');
 
 # Try a custom view
@@ -183,15 +112,15 @@ SELECT sys.format_statement(DIGEST_TEXT) AS query,
   FROM performance_schema.events_statements_summary_by_digest
  ORDER BY SUBSTRING(query, 1, 6);
 SET @sys.statement_performance_analyzer.view = 'test.view_digests';
---replace_result $query_insert QUERY_INSERT $query_select QUERY_SELECT $query_update QUERY_UPDATE $digest_insert DIGEST_INSERT $digest_update DIGEST_UPDATE $digest_select DIGEST_SELECT $o_upd_total_latency LATENCY $o_upd_avg_latency LATENCY $o_sel_total_latency LATENCY $o_sel_avg_latency LATENCY $o_ins_total_latency LATENCY $o_ins_avg_latency LATENCY
 CALL sys.statement_performance_analyzer('overall', NULL, 'custom');
---replace_result $query_insert QUERY_INSERT $query_select QUERY_SELECT $query_update QUERY_UPDATE $digest_insert DIGEST_INSERT $digest_update DIGEST_UPDATE $digest_select DIGEST_SELECT $d_upd_total_latency LATENCY $d_sel_total_latency LATENCY $d_ins_total_latency LATENCY
 CALL sys.statement_performance_analyzer('delta', 'test.tmp_digests_ini', 'custom');
 
 # Verify that setting a limit works
 SET @sys.statement_performance_analyzer.limit = 2;
---replace_result $query_insert QUERY_INSERT $query_select QUERY_SELECT $digest_insert DIGEST_INSERT $digest_select DIGEST_SELECT $o_ins_total_latency LATENCY $o_ins_avg_latency LATENCY $o_sel_total_latency LATENCY $o_sel_avg_latency LATENCY
 CALL sys.statement_performance_analyzer('overall', NULL, 'custom');
+
+--enable_result_log
+
 
 # Test for error conditions - some of the errors depend on the sql_mode so set it explicitly
 # Which sql_modes are deprecated depends on the release, so disable warnings while setting the sql_mode
@@ -292,4 +221,5 @@ SET SESSION sql_mode = @@global.sql_mode;
 SET @sys.statement_performance_analyzer.limit = NULL;
 SET @sys.statement_performance_analyzer.view = NULL;
 --source ../include/ps_setup_consumers_cleanup.inc
+--source ../include/ps_threads_cleanup.inc
 --source ../include/sys_config_cleanup.inc


### PR DESCRIPTION
…ck to avoid race issues on slow platforms where it's not always possible to ensure all data has been written to the Performance Schema tables and all required data is still available.