### PR TITLE
db_collation_convertor

### DIFF
--- a/procedures/db_collation_convertor.sql
+++ b/procedures/db_collation_convertor.sql
@@ -1,0 +1,70 @@
+--  Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+--
+--  This program is free software; you can redistribute it and/or modify
+--  it under the terms of the GNU General Public License as published by
+--  the Free Software Foundation; version 2 of the License.
+--
+--  This program is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--  GNU General Public License for more details.
+--
+--  You should have received a copy of the GNU General Public License
+--  along with this program; if not, write to the Free Software
+--  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+DROP PROCEDURE IF EXISTS db_collation_convertor;
+
+DELIMITER $$
+
+CREATE DEFINER='root'@'localhost' PROCEDURE db_collation_convertor (
+	in in_dbname varchar(100), in in_charset varchar(100) , in in_collation varchar(100)
+	)
+	COMMENT '
+		Description
+		-----------
+		Convert all tables in database to new character set and collation .
+
+
+		Parameters
+		-----------
+
+		in_dbname (varchar(100)):
+			The Database name
+		
+		in_charset (varchar(100)):
+			The Character Set name, Example utf8
+
+		in_collation (varchar(100)):
+			The Collation name, Example: ut8_persian_ci
+
+		Example
+		--------
+
+		mysql> CALL sys.db_collation_covertor(''dbname'',''utf8'',''utf8_persian_ci'');
+
+		Query OK, 0 rows affected (0.00 sec)
+            '
+BEGIN
+	DECLARE finish INT DEFAULT 0;
+	DECLARE tab varchar(100);
+	DECLARE db_tables CURSOR FOR select table_name from information_schema.tables WHERE table_schema = in_dbname and table_type = 'base table';
+	DECLARE continue HANDLER FOR NOT found SET finish = 1;
+	IF NOT EXISTS (select COLLATION_NAME , CHARACTER_SET_NAME from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME = in_collation and CHARACTER_SET_NAME = in_charset) THEN
+			SELECT CONCAT('Invalid collation "', in_collation ,'" with character set "', in_charset,'"') AS Summary;
+			SET finish = 1;
+	END IF;
+	OPEN db_tables;
+	dbcolconv: LOOP
+		FETCH db_tables INTO tab;
+		IF finish = 1 THEN
+			LEAVE dbcolconv;
+		END IF;
+		SET @sql = CONCAT('alter table ', tab,' convert to character set ',in_charset,' collate ', in_collation);
+		PREPARE stmt FROM @sql;
+		EXECUTE stmt;
+		DEALLOCATE PREPARE stmt;
+	END LOOP;
+		CLOSE db_tables;
+END; $$
+DELIMITER ;

--- a/sys_56.sql
+++ b/sys_56.sql
@@ -175,5 +175,6 @@ SOURCE ./procedures/ps_truncate_all_tables.sql
 
 SOURCE ./procedures/statement_performance_analyzer.sql
 SOURCE ./procedures/table_exists.sql
+SOURCE ./procedures/db_collation_convertor.sql
 
 SOURCE ./after_setup.sql

--- a/sys_57.sql
+++ b/sys_57.sql
@@ -191,5 +191,6 @@ SOURCE ./procedures/ps_truncate_all_tables.sql
 
 SOURCE ./procedures/statement_performance_analyzer.sql
 SOURCE ./procedures/table_exists.sql
+SOURCE ./procedures/db_collation_convertor.sql
 
 SOURCE ./after_setup.sql


### PR DESCRIPTION
Hello 

I create a procedure to convert all tables in the database to new character set and collation . 
```
mysql > CALL sys.db_collation_convertor('app','utf8','utf8_persian_ci');
```
it can handle errors when no table found or collation is not applicable with character set or one of them are invalid . 
```
mysql > CALL sys.db_collation_convertor('app','latin1','utf8_general_ci');
+--------------------------------------------------------------+
| Summary                                                      |
+--------------------------------------------------------------+
| Invalid collation "utf8_general_i" with character set "utf8" |
+--------------------------------------------------------------+
1 row in set (0.01 sec)
```
This is my first contribution i try to read current sql files for better coding and im glad if you guide me through this .

ps: I signed OCA today waiting for response .

Thank you . 
