### PR TITLE
The null characters (\0) from the IP addresses printed for 'wait/io/socket%' events cause errors while converting the output dot file.

### DIFF
--- a/procedures/ps_trace_thread_57.sql
+++ b/procedures/ps_trace_thread_57.sql
@@ -224,7 +224,7 @@ BEGIN
                             IF(object_name IS NOT NULL, 
                                IF (event_name LIKE 'wait/io/socket%',
                                    -- Print the socket if used, else the IP:port as reported
-                                   CONCAT('\\n', IF (object_name LIKE ':0%', @@socket, object_name)),
+                                   CONCAT('\\n', IF (object_name LIKE ':0%', @@socket, REPLACE(object_name,'\0',''))),
                                    object_name),
                                ''
                             ),


### PR DESCRIPTION
The null characters (\0) from the IP addresses printed for 'wait/io/socket%' events cause errors while converting the output dot file.

**How to reproduce**
Try to convert the dot file to PDF or any other format:
```
dot -Tpdf -o stack-2022-08-26-13:11:18.pdf stack-2022-08-26-13:11:18.dot
Warning: stack-2022-08-26-13:11:18.dot: syntax error in line 11 near '('
```



